### PR TITLE
[#46] 리더보드에 저장된 값이 없을 경우에 초기화 후 리더보드 업데이트하기

### DIFF
--- a/AppName/AppName/Helper/GameCenterManager.swift
+++ b/AppName/AppName/Helper/GameCenterManager.swift
@@ -33,16 +33,23 @@ class GameCenterManager: NSObject, GKGameCenterControllerDelegate, ObservableObj
     }
     
     // MARK: 순위표 점수 업데이트 하기
+    // TODO: 로컬의 인증 횟수를 저장해서 그 값을 리더보드에 업데이트하기
     func submitPoint(point: Int) async {
         let formerPoint = await loadFormerPoint()
         if formerPoint == -1 {
             print("Error: cannot load former point from leaderboard.")
-            return
-        }
-        GKLeaderboard.submitScore(formerPoint + Int(point), context: 0, player: GKLocalPlayer.local,
-                                  leaderboardIDs: [leaderboardID]) { error in
-            if error != nil {
-                print("Error: \(error!.localizedDescription).")
+            GKLeaderboard.submitScore(Int(point), context: 0, player: GKLocalPlayer.local,
+                                      leaderboardIDs: [leaderboardID]) { error in
+                if error != nil {
+                    print("Error: \(error!.localizedDescription).")
+                }
+            }
+        } else {
+            GKLeaderboard.submitScore(formerPoint + Int(point), context: 0, player: GKLocalPlayer.local,
+                                      leaderboardIDs: [leaderboardID]) { error in
+                if error != nil {
+                    print("Error: \(error!.localizedDescription).")
+                }
             }
         }
         print("game center: updated leaderboard")


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
리더보드에 저장된 점수가 없을 때 초기화 후 태깅된 점수를 업로드하도록 설정했습니다. 

하지만 테스트해보니 리더보드 자체가 서버를 이용하는 거라서 온라인이 아닌 경우 싱크가 안되고 값도 불러오지 못한다는 점에서 결국 로컬 저장소를 써야겠다는 결론이 낫습니다. Phase 3에 더 얘기해봐요!


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #46 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
처음 태깅하는 사람이라면 당연히 리더보드에 등록된 점수가 없을 거라서, 그 상황에 리더보드에서 값을 불러오지 못하면 새로 태깅한 점수를 통해 리더보드에 업로드할 수 있도록 코드를 추가했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
