### PR TITLE
[#86] 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수 수정

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -238,13 +238,20 @@ class HealthKitService: ObservableObject {
                     return
                 }
                 
-                let totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
+                var totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
+                
+                // 데이터가 없으면 0을 반환
+                if totalFlightsClimbed == 0.0 {
+                    totalFlightsClimbed = 0.0
+                    print("이번 주 계단 데이터가 없습니다. 0을 반환합니다.")
+                }
+                
                 UserDefaults(suiteName: "group.macmac.pratice.carot")?.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
-                // 이 부분에서 바로 @AppStorage의 값을 업데이트합니다.
+                // 이 부분에서 바로 @AppStorage의 값을 업데이트
                 DispatchQueue.main.async {
                     self.weeklyFlightsClimbed = totalFlightsClimbed
                 }
-                //                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
+                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
             }
             healthStore.execute(query)
         }


### PR DESCRIPTION
## 📌 Summary
토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수, 헬스킷에 값이 없으면 0 반환

수정하기 전에는, 이번 주 계단 데이터가 없을 경우 지난 주 데이터를 불러오는 로직이 포함되었음. totalFlightsClimbed가 0일 때, 지난 주 토요일부터 금요일까지의 데이터를 조회하여 UserDefaults와 weeklyFlightsClimbed에 저장하는 방식이었음.

이번에 수정하면서 이번 주 데이터가 없으면 지난 주 데이터를 가져오지 않고, 0을 반환하도록 변경함. (의도대로)


## ✍️ Description
- 이슈 티켓 : resolved #86 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
