### PR TITLE
[#135] 권한일과 토요일 시작 지점 문제 핸들링, 매주 토요일 기준으로 데이터를 초기화해 의도대로 동작하게 함

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -251,8 +251,6 @@ class HealthKitService: ObservableObject {
                 print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
                 
                 print("Authorization Date: \(String(describing: authorizationDate)), Start: \(adjustedStartDate), End: \(endOfWeekDate)")
-                //                                                 print("주간 계단 수 (토요일 시작): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
-                //                                       print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
             }
             healthStore.execute(query)
         }

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -528,7 +528,7 @@ struct MainViewPhase3: View {
         let weeklyNfcPoint = weeklyScore(from: stairSteps)
         service.getWeeklyStairDataAndSave()
         let weeklyStairPoint = service.weeklyFlightsClimbed * 16
-                print("이번주 걸은 층계 * 16: \(weeklyStairPoint), nfc 점수: \(weeklyNfcPoint)")
+//                print("이번주 걸은 층계 * 16: \(weeklyStairPoint), nfc 점수: \(weeklyNfcPoint)")
         Task {
             await gameCenterManager.submitPoint(point: Int(weeklyNfcPoint) + Int(weeklyStairPoint))
         }


### PR DESCRIPTION
## 📌 Summary
권한일과 토요일 시작 지점 문제 핸들링, 매주 토요일 기준으로 데이터를 초기화해 의도대로 동작하게 함

## ✍️ Description

1. 원래 코드는 권한일vs토요일 중 더 늦은 날을 단순히 max로 비교해서 첫주에는 권한일이 더 늦는게 당연하므로, 정상적으로 작동했지만 다음주로 진입하면서 권한일이 더 앞서게 되면서 권한일부터 토요일까지 데이터가 담기는 의도하지 않는 계산 방식이 됨.

2. 첫주에는 권한 날짜와 토요일 중 더 늦은 날짜를 사용하도록하고, 이후 주부터는 항상 토요일을 기준으로 시작일을 설정하도록 함수를 수정함.

3. 이 과정에서 캘린더 익스텐션을 추가함.

- 이슈 티켓 : resolved #135 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
