### PR TITLE
[#152] 저장소 저장 방식 통일해서 권한날짜 덮어씌어지지 않는 에러 핸들링

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -113,6 +113,15 @@ class HealthKitService: ObservableObject {
             
             let totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
             
+            // 새로운 권한 날짜 이후 데이터가 없을 경우 처리
+            if totalFlightsClimbed == 0.0 {
+                // App Group UserDefaults 초기화
+                appGroupDefaults.set(0.0, forKey: "TotalFlightsClimbedSinceAuthorization")
+                appGroupDefaults.set(nil, forKey: "LastFetchTime")
+                print("새로운 권한 날짜 이후 데이터가 없으므로 계단 수를 0으로 초기화했습니다.")
+                return
+            }
+            
             // 날짜 포맷 설정
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "ko_KR")
@@ -176,7 +185,6 @@ class HealthKitService: ObservableObject {
     
     
     
-    // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
     // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
     func getWeeklyStairDataAndSave() {
         if let stairType = HKObjectType.quantityType(forIdentifier: .flightsClimbed) {

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -107,7 +107,8 @@ class HealthKitService: ObservableObject {
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
             if let error = error {
-                print("계단 오르기 데이터 가져오기 오류: \(error.localizedDescription)")
+                print("계단 오르기 데이터 가져오기 오류: \(error.localizedDescription) 혹은 데이터가 0입니다.")
+                print("Authorization Date: \(String(describing: authorizationDate))")
                 return
             }
             
@@ -119,6 +120,7 @@ class HealthKitService: ObservableObject {
                 appGroupDefaults.set(0.0, forKey: "TotalFlightsClimbedSinceAuthorization")
                 appGroupDefaults.set(nil, forKey: "LastFetchTime")
                 print("새로운 권한 날짜 이후 데이터가 없으므로 계단 수를 0으로 초기화했습니다.")
+                
                 return
             }
             
@@ -245,7 +247,7 @@ class HealthKitService: ObservableObject {
             
             let query = HKStatisticsQuery(quantityType: stairType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
                 guard error == nil else {
-                    print("주간 계단 데이터 가져오기 오류: \(error!.localizedDescription)")
+                    print("주간 계단 데이터 가져오기 오류: \(error!.localizedDescription) 혹은 주간 계단 데이터가 0입니다.")
                     DispatchQueue.main.async {
                         self.weeklyFlightsClimbed = 0.0
                     }

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -20,9 +20,8 @@ class HealthKitService: ObservableObject {
     @AppStorage("WeeklyFlightsClimbed", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var weeklyFlightsClimbed: Double = 0.0
     @AppStorage("TotalFlightsClimbedSinceAuthorization", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var TotalFlightsClimbedSinceAuthorization: Double = 0.0
     @AppStorage("LastFetchTime", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var LastFetchTime: String = ""
-    @AppStorage("authorizationDateKey", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var authorizationDateKey: String = ""
+    @AppStorage("HealthKitAuthorizationDate", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var authorizationDateKey: String = ""
     @AppStorage("HealthKitAuthorized") var isHealthKitAuthorized: Bool = false
-    @AppStorage("ReserButtonPressed") var reserButtonPressed: Bool = false
     
     
     
@@ -49,11 +48,12 @@ class HealthKitService: ObservableObject {
                 self?.fetchAllFlightsClimbedData()
                 // 권한 요청 날짜를 기록하는 로직
                 self?.storeAuthorizationDate()
+                self?.fetchAndSaveFlightsClimbedSinceButtonPress()
                 
                 // 권한 허용 후에만 데이터를 가져오는 로직 실행
                 self?.getWeeklyStairDataAndSave()
                 self?.fetchAndSaveFlightsClimbedSinceAuthorization()
-                self?.fetchAndSaveFlightsClimbedSinceButtonPress()
+                
             } else {
                 self?.isHealthKitAuthorized = false
                 //                self?.isHealthKitAuthorized = false
@@ -66,19 +66,12 @@ class HealthKitService: ObservableObject {
     // 권한 허용 날짜를 UserDefaults에 저장하는 함수
     private func storeAuthorizationDate() {
         let authorizationDateKey = "HealthKitAuthorizationDate"
+        let defaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
         
-        // UserDefaults에 날짜가 저장되어 있는지 확인
-        if UserDefaults.standard.object(forKey: authorizationDateKey) == nil {
+        if defaults?.object(forKey: authorizationDateKey) == nil {
             let currentDate = Date()
-            
-            // 권한 허용 날짜 저장
-            UserDefaults.standard.set(currentDate, forKey: authorizationDateKey)
+            defaults?.set(currentDate, forKey: authorizationDateKey)
             print("HealthKit 권한 허용 날짜를 \(currentDate)로 저장했습니다.")
-        } else {
-            // 이미 날짜가 저장된 경우, 기존 날짜를 사용
-            if UserDefaults.standard.object(forKey: authorizationDateKey) is Date {
-                //                print("이전에 저장된 HealthKit 권한 허용 날짜: \(savedDate)")
-            }
         }
     }
     
@@ -86,7 +79,14 @@ class HealthKitService: ObservableObject {
     
     // MARK: - 헬스킷 권한을 받은 당일 부터의 계단 오르기 데이터를 가져오는 기능
     func fetchAndSaveFlightsClimbedSinceAuthorization() {
-        guard let authorizationDate = UserDefaults.standard.object(forKey: "HealthKitAuthorizationDate") as? Date else {
+        // App Group UserDefaults를 사용
+        guard let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot") else {
+            print("App Group 저장소를 초기화하는 데 실패했습니다.")
+            return
+        }
+        
+        // 권한 허용 날짜 가져오기
+        guard let authorizationDate = appGroupDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date else {
             print("권한 허용 날짜가 설정되지 않았습니다.")
             return
         }
@@ -102,10 +102,8 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
         // 데이터 소스 필터링을 위한 추가 조건
-        // 사용자가 데이터를 주작했는지 아닌지 파악하는 부분 NSPredicate -> 메타 데이터 쿼리 조건, yes가 아닌 데이터만 가져 오겠다는 것.
         let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
-        
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
             if let error = error {
@@ -124,10 +122,9 @@ class HealthKitService: ObservableObject {
             let currentFetchTime = Date()
             let formattedFetchTime = formatter.string(from: currentFetchTime)
             
-            // UserDefaults에 계단 데이터와 함께 패치 시각 저장
-            let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
-            appGroupDefaults?.set(totalFlightsClimbed, forKey: "TotalFlightsClimbedSinceAuthorization")
-            appGroupDefaults?.set(formattedFetchTime, forKey: "LastFetchTime") // 포맷된 패치 시각 저장
+            // App Group UserDefaults에 계단 데이터와 함께 패치 시각 저장
+            appGroupDefaults.set(totalFlightsClimbed, forKey: "TotalFlightsClimbedSinceAuthorization")
+            appGroupDefaults.set(formattedFetchTime, forKey: "LastFetchTime") // 포맷된 패치 시각 저장
             
             // 패치 결과를 콘솔에 출력
             print("총 계단 오르기 수 \(totalFlightsClimbed)를 저장했습니다. (패치 시각: \(formattedFetchTime))")
@@ -135,6 +132,7 @@ class HealthKitService: ObservableObject {
         
         healthStore.execute(query)
     }
+    
     
     // MARK: - 헬스킷 권한을 받았는지 아닌지를 확인하기 위해 전체 계단오르기 데이터를 호출해서 isHealthKitAuthorized를 업데이트하는 함수
     func fetchAllFlightsClimbedData() {
@@ -179,6 +177,7 @@ class HealthKitService: ObservableObject {
     
     
     // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
+    // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
     func getWeeklyStairDataAndSave() {
         if let stairType = HKObjectType.quantityType(forIdentifier: .flightsClimbed) {
             let calendar = Calendar.current
@@ -202,8 +201,14 @@ class HealthKitService: ObservableObject {
                 return
             }
             
+            // App Group UserDefaults 가져오기
+            guard let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot") else {
+                print("App Group 저장소를 초기화하는 데 실패했습니다.")
+                return
+            }
+            
             // 권한 허용 날짜 가져오기
-            guard let authorizationDate = UserDefaults.standard.object(forKey: "HealthKitAuthorizationDate") as? Date else {
+            guard let authorizationDate = appGroupDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date else {
                 print("권한 허용 날짜가 설정되지 않았습니다.")
                 return
             }
@@ -225,7 +230,6 @@ class HealthKitService: ObservableObject {
             }
             
             // HealthKit 쿼리 실행
-            //            let adjustedStartDateMinusOneDay = Calendar.current.date(byAdding: .day, value: -1, to: adjustedStartDate)!
             let predicate = HKQuery.predicateForSamples(withStart: adjustedStartDate, end: endOfWeekDate, options: [])
             
             let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
@@ -241,28 +245,33 @@ class HealthKitService: ObservableObject {
                 }
                 
                 let totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
-                UserDefaults(suiteName: "group.macmac.pratice.carot")?.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
+                appGroupDefaults.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
                 
                 DispatchQueue.main.async {
                     self.weeklyFlightsClimbed = totalFlightsClimbed
                 }
-                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
+                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 App Group UserDefaults에 저장했습니다.")
                 print("Authorization Date: \(String(describing: authorizationDate)), Start: \(adjustedStartDate), End: \(endOfWeekDate)")
             }
             healthStore.execute(query)
         }
     }
     
+    
     // MARK: - 리셋 버튼을 누르면 현재 시간을 권한 허용 날짜로 대신하여 오늘 0시 부터의 데이터 패치 됨.
     func fetchAndSaveFlightsClimbedSinceButtonPress() {
         
         // 현재 시각을 버튼 누른 시각으로 저장 (HealthKitAuthorizationDate로 사용)
         let now = Date()
-        UserDefaults.standard.set(now, forKey: "HealthKitAuthorizationDate")
+        if let defaults = UserDefaults(suiteName: "group.macmac.pratice.carot") {
+            defaults.set(now, forKey: "HealthKitAuthorizationDate")
+        } else {
+            print("App Group 저장소를 초기화하는 데 실패했습니다.")
+        }
         
         fetchAndSaveFlightsClimbedSinceAuthorization()
-        
     }
+    
     
     
     

--- a/StepSquad/StepSquad/View/EntryCertificateView.swift
+++ b/StepSquad/StepSquad/View/EntryCertificateView.swift
@@ -128,17 +128,18 @@ struct EntryCertificateView: View {
 
     // MARK: - 유저디폴트에 저장된 날짜 가져오기
     func loadHealthKitAuthorizationDate() {
-        let userDefaults = UserDefaults.standard
+        // App Group 저장소 사용으로 수정
+        let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
 
-        if let storedDate = userDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date {
+        if let storedDate = appGroupDefaults?.object(forKey: "HealthKitAuthorizationDate") as? Date {
             let formatter = DateFormatter()
-
+            
             formatter.dateFormat = "yyyy년 MM월 dd일"
             formatter.locale = Locale(identifier: "ko_KR")
             formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-
+            
             formattedDate = formatter.string(from: storedDate)
-
+            
             calculateDDay(from: storedDate)
         } else {
             formattedDate = "날짜 없음"


### PR DESCRIPTION
## 📌 Summary
1. 저장소 저장 방식 통일해서 권한날짜 덮어씌어지지 않는 에러 핸들링 #152
2. HealthKit 뷰에 변경 사항이 많으므로 코드 전체를 복사 붙여 넣기해서 #149 브랜치에서 작업 하시길 권함.

## ✍️ Description
- 이슈 티켓 : resolved #152 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
저장소 저장 방식 문제 였던 것 같습니다.

## 📚 Reference 
프린트문으로 권한 날짜가 새롭게 덮어씌워진 것 확인
<img width="662" alt="스크린샷 2025-01-14 오후 1 59 26" src="https://github.com/user-attachments/assets/12839931-cc94-47ce-b501-296dc9a61ea0" />



## 🔥 Test
<!-- Test -->
