### PR TITLE
[Fix]

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -304,16 +304,3 @@ extension UserDefaults {
         return UserDefaults(suiteName: appGroupId)!
     }
 }
-        } else {
-            //print("기본 UserDefaults에 저장된 HealthKit 권한 상태가 없습니다.")
-        }
-    }
-}
-
-
-extension UserDefaults {
-    static var shared: UserDefaults {
-        let appGroupId = "group.com.stepSquad.widget"
-        return UserDefaults(suiteName: appGroupId)!
-    }
-}

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -20,9 +20,7 @@ class HealthKitService: ObservableObject {
     @AppStorage("WeeklyFlightsClimbed", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var weeklyFlightsClimbed: Double = 0.0
     @AppStorage("TotalFlightsClimbedSinceAuthorization", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var TotalFlightsClimbedSinceAuthorization: Double = 0.0
     @AppStorage("LastFetchTime", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var LastFetchTime: String = ""
-    @AppStorage("HealthKitAuthorizationDate", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var authorizationDateKey: String = ""
     @AppStorage("HealthKitAuthorized") var isHealthKitAuthorized: Bool = false
-    
     
     
     // MARK: - HealthKit 사용 권한을 요청하는 메서드
@@ -48,12 +46,11 @@ class HealthKitService: ObservableObject {
                 self?.fetchAllFlightsClimbedData()
                 // 권한 요청 날짜를 기록하는 로직
                 self?.storeAuthorizationDate()
-                self?.fetchAndSaveFlightsClimbedSinceButtonPress()
                 
                 // 권한 허용 후에만 데이터를 가져오는 로직 실행
                 self?.getWeeklyStairDataAndSave()
                 self?.fetchAndSaveFlightsClimbedSinceAuthorization()
-                
+                //                self?.fetchAndSaveFlightsClimbedSinceButtonPress()
             } else {
                 self?.isHealthKitAuthorized = false
                 //                self?.isHealthKitAuthorized = false
@@ -66,27 +63,26 @@ class HealthKitService: ObservableObject {
     // 권한 허용 날짜를 UserDefaults에 저장하는 함수
     private func storeAuthorizationDate() {
         let authorizationDateKey = "HealthKitAuthorizationDate"
-        let defaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
         
-        if defaults?.object(forKey: authorizationDateKey) == nil {
+        // UserDefaults에 날짜가 저장되어 있는지 확인
+        if UserDefaults.standard.object(forKey: authorizationDateKey) == nil {
             let currentDate = Date()
-            defaults?.set(currentDate, forKey: authorizationDateKey)
+            
+            // 권한 허용 날짜 저장
+            UserDefaults.standard.set(currentDate, forKey: authorizationDateKey)
             print("HealthKit 권한 허용 날짜를 \(currentDate)로 저장했습니다.")
+        } else {
+            // 이미 날짜가 저장된 경우, 기존 날짜를 사용
+            if UserDefaults.standard.object(forKey: authorizationDateKey) is Date {
+                print("1. Authorization Date: \(String(describing: authorizationDateKey))")
+            }
         }
     }
     
     
-    
     // MARK: - 헬스킷 권한을 받은 당일 부터의 계단 오르기 데이터를 가져오는 기능
     func fetchAndSaveFlightsClimbedSinceAuthorization() {
-        // App Group UserDefaults를 사용
-        guard let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot") else {
-            print("App Group 저장소를 초기화하는 데 실패했습니다.")
-            return
-        }
-        
-        // 권한 허용 날짜 가져오기
-        guard let authorizationDate = appGroupDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date else {
+        guard let authorizationDate = UserDefaults.standard.object(forKey: "HealthKitAuthorizationDate") as? Date else {
             print("권한 허용 날짜가 설정되지 않았습니다.")
             return
         }
@@ -97,58 +93,59 @@ class HealthKitService: ObservableObject {
         }
         
         // 권한 허용 날짜의 자정으로 시작 시점 설정
-        let calendar = Calendar.current
-        let startOfAuthorizationDate = calendar.startOfDay(for: authorizationDate)
+        let startOfAuthorizationDate = Calendar.current.startOfDay(for: authorizationDate)
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
-        // 데이터 소스 필터링을 위한 추가 조건
+        // 사용자 입력 데이터를 제외한 조건 추가
         let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
+            // 오류가 발생한 경우 기본값을 0.0으로 설정
             if let error = error {
-                print("계단 오르기 데이터 가져오기 오류: \(error.localizedDescription) 혹은 데이터가 0입니다.")
-                print("Authorization Date: \(String(describing: authorizationDate))")
+                print("2.계단 오르기 데이터를 가져오는 중 오류 발생: \(error.localizedDescription)")
+                self.saveFlightsClimbedToDefaults(0.0, authorizationDate: authorizationDate)
                 return
             }
             
+            // 결과에서 데이터 가져오기 (없을 경우 기본값 0.0)
             let totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
             
-            // 새로운 권한 날짜 이후 데이터가 없을 경우 처리
+            // 데이터가 없는 경우 기본값 0.0 저장
             if totalFlightsClimbed == 0.0 {
-                // App Group UserDefaults 초기화
-                appGroupDefaults.set(0.0, forKey: "TotalFlightsClimbedSinceAuthorization")
-                appGroupDefaults.set(nil, forKey: "LastFetchTime")
-                print("새로운 권한 날짜 이후 데이터가 없으므로 계단 수를 0으로 초기화했습니다.")
-                
-                return
+                print("2.권한 이후 계단 오르기 데이터가 없습니다. 기본값 0.0을 저장합니다.")
             }
             
-            // 날짜 포맷 설정
-            let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "ko_KR")
-            formatter.dateFormat = "a hh:mm, yyyy/MM/dd" // "오후 11:29, 2024/11/10" 형식
-            
-            // 현재 시각 포맷팅
-            let currentFetchTime = Date()
-            let formattedFetchTime = formatter.string(from: currentFetchTime)
-            
-            // App Group UserDefaults에 계단 데이터와 함께 패치 시각 저장
-            appGroupDefaults.set(totalFlightsClimbed, forKey: "TotalFlightsClimbedSinceAuthorization")
-            appGroupDefaults.set(formattedFetchTime, forKey: "LastFetchTime") // 포맷된 패치 시각 저장
-            
-            // 패치 결과를 콘솔에 출력
-            print("총 계단 오르기 수 \(totalFlightsClimbed)를 저장했습니다. (패치 시각: \(formattedFetchTime))")
+            // 데이터를 UserDefaults에 저장
+            self.saveFlightsClimbedToDefaults(totalFlightsClimbed, authorizationDate: authorizationDate)
         }
         
         healthStore.execute(query)
+    }
+    
+    private func saveFlightsClimbedToDefaults(_ flightsClimbed: Double, authorizationDate: Date) {
+        // 현재 시각 포맷팅
+        let currentFetchTime = Date()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "a hh:mm, yyyy/MM/dd" // "오후 11:29, 2024/11/10"
+        let formattedFetchTime = formatter.string(from: currentFetchTime)
+        
+        // UserDefaults에 계단 데이터와 패치 시각 저장
+        let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
+        appGroupDefaults?.set(flightsClimbed, forKey: "TotalFlightsClimbedSinceAuthorization")
+        appGroupDefaults?.set(formattedFetchTime, forKey: "LastFetchTime")
+        
+        // 저장 결과 출력
+        print("2. 총 계단 오르기 수 \(flightsClimbed)를 저장했습니다. (패치 시각: \(formattedFetchTime))")
+        print("2. Authorization Date: \(authorizationDate)")
     }
     
     
     // MARK: - 헬스킷 권한을 받았는지 아닌지를 확인하기 위해 전체 계단오르기 데이터를 호출해서 isHealthKitAuthorized를 업데이트하는 함수
     func fetchAllFlightsClimbedData() {
         guard let flightsClimbedType = HKObjectType.quantityType(forIdentifier: .flightsClimbed) else {
-            print("계단 오르기 데이터 타입을 찾을 수 없습니다.")
+            print("3. 계단 오르기 데이터 타입을 찾을 수 없습니다.")
             return
         }
         
@@ -161,7 +158,7 @@ class HealthKitService: ObservableObject {
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { [weak self] _, result, error in
             if let error = error {
-                print("전체 계단 오르기 데이터 가져오기 오류: \(error.localizedDescription)")
+                print("3. 전체 계단 오르기 데이터 가져오기 오류: \(error.localizedDescription)")
                 DispatchQueue.main.async {
                     self?.isHealthKitAuthorized = false
                 }
@@ -178,7 +175,7 @@ class HealthKitService: ObservableObject {
                     self?.isHealthKitAuthorized = false
                 }
                 
-                print("전체 계단 오르기 데이터: \(totalFlightsClimbed)")
+                print("3. 전체 계단 오르기 데이터: \(totalFlightsClimbed)")
             }
         }
         
@@ -211,15 +208,9 @@ class HealthKitService: ObservableObject {
                 return
             }
             
-            // App Group UserDefaults 가져오기
-            guard let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot") else {
-                print("App Group 저장소를 초기화하는 데 실패했습니다.")
-                return
-            }
-            
             // 권한 허용 날짜 가져오기
-            guard let authorizationDate = appGroupDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date else {
-                print("권한 허용 날짜가 설정되지 않았습니다.")
+            guard let authorizationDate = UserDefaults.standard.object(forKey: "HealthKitAuthorizationDate") as? Date else {
+                print("4. 권한 허용 날짜가 설정되지 않았습니다.")
                 return
             }
             
@@ -235,11 +226,12 @@ class HealthKitService: ObservableObject {
             
             // 권한 허용일이 주간 범위를 벗어난 경우 처리
             if adjustedStartDate > endOfWeekDate {
-                print("권한 허용일이 주간 범위에 포함되지 않습니다.")
+                print("4. 권한 허용일이 주간 범위에 포함되지 않습니다.")
                 return
             }
             
             // HealthKit 쿼리 실행
+            //            let adjustedStartDateMinusOneDay = Calendar.current.date(byAdding: .day, value: -1, to: adjustedStartDate)!
             let predicate = HKQuery.predicateForSamples(withStart: adjustedStartDate, end: endOfWeekDate, options: [])
             
             let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
@@ -247,7 +239,7 @@ class HealthKitService: ObservableObject {
             
             let query = HKStatisticsQuery(quantityType: stairType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
                 guard error == nil else {
-                    print("주간 계단 데이터 가져오기 오류: \(error!.localizedDescription) 혹은 주간 계단 데이터가 0입니다.")
+                    print("4.주간 계단 데이터 가져오기 오류: \(error!.localizedDescription) 혹은 데이터가 0입니다.")
                     DispatchQueue.main.async {
                         self.weeklyFlightsClimbed = 0.0
                     }
@@ -255,33 +247,28 @@ class HealthKitService: ObservableObject {
                 }
                 
                 let totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
-                appGroupDefaults.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
+                UserDefaults(suiteName: "group.macmac.pratice.carot")?.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
                 
                 DispatchQueue.main.async {
                     self.weeklyFlightsClimbed = totalFlightsClimbed
                 }
-                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 App Group UserDefaults에 저장했습니다.")
-                print("Authorization Date: \(String(describing: authorizationDate)), Start: \(adjustedStartDate), End: \(endOfWeekDate)")
+                print("4.주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
+                print("4.Authorization Date: \(String(describing: authorizationDate)), Start: \(adjustedStartDate), End: \(endOfWeekDate)")
             }
             healthStore.execute(query)
         }
     }
-    
     
     // MARK: - 리셋 버튼을 누르면 현재 시간을 권한 허용 날짜로 대신하여 오늘 0시 부터의 데이터 패치 됨.
     func fetchAndSaveFlightsClimbedSinceButtonPress() {
         
         // 현재 시각을 버튼 누른 시각으로 저장 (HealthKitAuthorizationDate로 사용)
         let now = Date()
-        if let defaults = UserDefaults(suiteName: "group.macmac.pratice.carot") {
-            defaults.set(now, forKey: "HealthKitAuthorizationDate")
-        } else {
-            print("App Group 저장소를 초기화하는 데 실패했습니다.")
-        }
+        UserDefaults.standard.set(now, forKey: "HealthKitAuthorizationDate")
         
         fetchAndSaveFlightsClimbedSinceAuthorization()
+        
     }
-    
     
     
     
@@ -304,6 +291,19 @@ class HealthKitService: ObservableObject {
             // Shared UserDefaults로 권한 상태 저장
             UserDefaults.shared.set(isAuthorized, forKey: "widgetAuthorizationStatus")
             //print("기존 HealthKit 권한 상태 \(isAuthorized)를 Shared Defaults로 옮겼습니다.")
+        } else {
+            //print("기본 UserDefaults에 저장된 HealthKit 권한 상태가 없습니다.")
+        }
+    }
+}
+
+
+extension UserDefaults {
+    static var shared: UserDefaults {
+        let appGroupId = "group.com.stepSquad.widget"
+        return UserDefaults(suiteName: appGroupId)!
+    }
+}
         } else {
             //print("기본 UserDefaults에 저장된 HealthKit 권한 상태가 없습니다.")
         }

--- a/StepSquad/StepSquad/View/EntryCertificateView.swift
+++ b/StepSquad/StepSquad/View/EntryCertificateView.swift
@@ -128,18 +128,17 @@ struct EntryCertificateView: View {
 
     // MARK: - 유저디폴트에 저장된 날짜 가져오기
     func loadHealthKitAuthorizationDate() {
-        // App Group 저장소 사용으로 수정
-        let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
+        let userDefaults = UserDefaults.standard
 
-        if let storedDate = appGroupDefaults?.object(forKey: "HealthKitAuthorizationDate") as? Date {
+        if let storedDate = userDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date {
             let formatter = DateFormatter()
-            
+
             formatter.dateFormat = "yyyy년 MM월 dd일"
             formatter.locale = Locale(identifier: "ko_KR")
             formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-            
+
             formattedDate = formatter.string(from: storedDate)
-            
+
             calculateDDay(from: storedDate)
         } else {
             formattedDate = "날짜 없음"


### PR DESCRIPTION
## 📌 Summary
1. 데이터 저장 방식 원래대로 되돌림, 리셋 후 데이터가 0일 때 생기던 오류 수정
2. 입단증에 들어가는 날짜 저장 방식 롤백


## ✍️ Description
- 이슈 티켓 : resolved 
- 피그마 : 
- 관련 문서 : #154 

## 💡 PR Point
문제 : 만랩에서 새로 권한을 받은 날의 데이터가 0이아닌 다른 값(1,2층)등이 있으면 제대로 읽히는데, 데이터가 0이면 생기는 문제.
이유 : 그전에 남아있던 값이 권한 이후의 날짜 당일 값이 0이면 오류로 분기 처리 되는데, 그때 0.0 대입 함.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
