### PR TITLE
[Fix]입단증 날짜는 초기 권한 날짜로 유지되도록 수정

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -63,6 +63,7 @@ class HealthKitService: ObservableObject {
     // 권한 허용 날짜를 UserDefaults에 저장하는 함수
     private func storeAuthorizationDate() {
         let authorizationDateKey = "HealthKitAuthorizationDate"
+        let authorizationDateKeyOriginal = "HealthKitAuthorizationDateOriginal"
         
         // UserDefaults에 날짜가 저장되어 있는지 확인
         if UserDefaults.standard.object(forKey: authorizationDateKey) == nil {
@@ -70,6 +71,7 @@ class HealthKitService: ObservableObject {
             
             // 권한 허용 날짜 저장
             UserDefaults.standard.set(currentDate, forKey: authorizationDateKey)
+            UserDefaults.standard.set(currentDate, forKey: authorizationDateKeyOriginal)
             print("HealthKit 권한 허용 날짜를 \(currentDate)로 저장했습니다.")
         } else {
             // 이미 날짜가 저장된 경우, 기존 날짜를 사용
@@ -185,6 +187,7 @@ class HealthKitService: ObservableObject {
     
     
     // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
+    // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
     func getWeeklyStairDataAndSave() {
         if let stairType = HKObjectType.quantityType(forIdentifier: .flightsClimbed) {
             let calendar = Calendar.current
@@ -234,7 +237,7 @@ class HealthKitService: ObservableObject {
             //            let adjustedStartDateMinusOneDay = Calendar.current.date(byAdding: .day, value: -1, to: adjustedStartDate)!
             let predicate = HKQuery.predicateForSamples(withStart: adjustedStartDate, end: endOfWeekDate, options: [])
             
-            let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
+            let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
             let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
             
             let query = HKStatisticsQuery(quantityType: stairType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in

--- a/StepSquad/StepSquad/View/EntryCertificateView.swift
+++ b/StepSquad/StepSquad/View/EntryCertificateView.swift
@@ -13,25 +13,25 @@ struct EntryCertificateView: View {
     @State private var isSharing: Bool = false
     @State private var sharedImage: UIImage?
     @State private var isButtonClicked: Bool = false
-
+    
     var userPlayerImage: Image?
     var nickName: String?
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
                 Text("계단사랑단 입단증")
                     .font(Font.custom("ChosunCentennial", size: 15))
                     .foregroundStyle(Color(hex: 0x4C6D38))
-
+                
                 Spacer()
-
+                
                 Text("StepSquad")
                     .font(Font.custom("ChosunCentennial", size: 15))
                     .foregroundStyle(Color(hex: 0x7EB55D))
             }
             .padding(.top, 18)
-
+            
             ZStack(alignment: .topLeading) {
                 if nickName == nil {
                     Image("entryCertiNoLog")
@@ -42,16 +42,16 @@ struct EntryCertificateView: View {
                         .resizable()
                         .scaledToFit()
                 }
-
+                
                 VStack(alignment: .leading, spacing: 0) {
                     Text("계단 오르기 맹세한 지")
                         .font(.system(size: 22))
                         .foregroundStyle(Color(hex: 0x4C6D38))
-
+                    
                     Text("\(dDay)일 차")
                         .font(.system(size: 34, weight: .bold))
                         .foregroundStyle(Color(hex: 0x3A542B))
-
+                    
                     if let userIMG = userPlayerImage {
                         userIMG
                             .resizable()
@@ -66,31 +66,31 @@ struct EntryCertificateView: View {
                 .padding(.leading, 20)
             }
             .padding(.top, 12)
-
+            
             Text(nickName ?? "계단 오르기를 실천하는 사람")
                 .font(.system(size: 22, weight: .bold))
                 .multilineTextAlignment(.leading)
                 .padding(.top, 8)
-
+            
             Text("\(formattedDate) 입단")
                 .font(.system(size: 13))
                 .foregroundStyle(Color(hex: 0x4C6D38))
-
+            
             Spacer()
-
-
+            
+            
             HStack(alignment: .bottom, spacing: 0) {
                 Text("계단사랑단")
                     .font(Font.custom("ChosunCentennial", size: 15))
                     .foregroundStyle(Color(hex: 0x3A542B))
                     .padding(.trailing, 5)
-
+                
                 Text("StepSquad")
                     .font(Font.custom("ChosunCentennial", size: 15))
                     .foregroundStyle(Color(hex: 0x7EB55D))
-
+                
                 Spacer()
-
+                
                 if !isButtonClicked {
                     Button {
                         isButtonClicked = true
@@ -110,7 +110,7 @@ struct EntryCertificateView: View {
                 }
             }
             .padding(.bottom, 23)
-
+            
         }
         .padding(.horizontal, 20)
         .frame(width: 321, height: 560)
@@ -125,49 +125,49 @@ struct EntryCertificateView: View {
             }
         }
     }
-
+    
     // MARK: - 유저디폴트에 저장된 날짜 가져오기
     func loadHealthKitAuthorizationDate() {
         let userDefaults = UserDefaults.standard
-
-        if let storedDate = userDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date {
+        
+        if let storedDate = userDefaults.object(forKey: "HealthKitAuthorizationDateOriginal") as? Date {
             let formatter = DateFormatter()
-
+            
             formatter.dateFormat = "yyyy년 MM월 dd일"
             formatter.locale = Locale(identifier: "ko_KR")
             formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-
+            
             formattedDate = formatter.string(from: storedDate)
-
+            
             calculateDDay(from: storedDate)
         } else {
             formattedDate = "날짜 없음"
             dDay = 0
         }
     }
-
+    
     // MARK: - 디데이 계산
     func calculateDDay(from date: Date) {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         let targetDate = calendar.startOfDay(for: date)
-
+        
         let components = calendar.dateComponents([.day], from: targetDate, to: today)
-
+        
         if let daysPassed = components.day {
             dDay = daysPassed + 1
         } else {
             dDay = 0
         }
     }
-
+    
     func captureAndShare() {
         let renderer = ImageRenderer(content: self)
-
+        
         // 원하는 해상도로 크기 조정
         _ = CGSize(width: 321 * 3, height: 560 * 3) // 3배 스케일
         renderer.scale = 3.0 // 디스플레이의 배율에 따라 조정
-
+        
         if let uiImage = renderer.uiImage {
             sharedImage = uiImage
             isSharing = true


### PR DESCRIPTION
## 📌 Summary
입단증 날짜는 초기 권한 날짜로 유지되도록 수정


## ✍️ Description
- 이슈 티켓 : resolved 
- 피그마 : 
- 관련 문서 : #156

## 💡 PR Point
같은 키를 가지는 날짜 저장소를 다른 키값을 가진 유저디폴트를 생성해서 기존 날짜를 덮어씌우지 않도록 수정.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
