### PR TITLE
[#149] 레벨 리셋하기

### DIFF
--- a/StepSquad/StepSquad.xcodeproj/project.pbxproj
+++ b/StepSquad/StepSquad.xcodeproj/project.pbxproj
@@ -323,9 +323,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.1.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadStickers/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadStickers;
@@ -335,6 +337,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadStickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = imessageStickerExtension;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -498,10 +501,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = StepSquad.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.1.1;
 				DEVELOPMENT_ASSET_PATHS = "\"StepSquad/Preview Content\"";
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StepSquad-Info.plist";
@@ -524,6 +529,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepSquadApp;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -541,10 +547,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = StepSquad.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.1.1;
 				DEVELOPMENT_ASSET_PATHS = "\"StepSquad/Preview Content\"";
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StepSquad-Info.plist";
@@ -567,6 +575,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepSquadApp;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -584,9 +593,11 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = StepSquadWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.1.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadWidget;
@@ -601,6 +612,8 @@
 				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepsQuadAppWidget;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -619,9 +632,11 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = StepSquadWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.1.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadWidget;
@@ -636,6 +651,8 @@
 				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepsQuadAppWidget;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -97,7 +97,7 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
         // 사용자 입력 데이터를 제외한 조건 추가
-        let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
+        let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -102,7 +102,7 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
         // 데이터 소스 필터링을 위한 추가 조건
-        let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
+        let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
@@ -232,7 +232,7 @@ class HealthKitService: ObservableObject {
             // HealthKit 쿼리 실행
             let predicate = HKQuery.predicateForSamples(withStart: adjustedStartDate, end: endOfWeekDate, options: [])
             
-            let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
+            let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
             let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
             
             let query = HKStatisticsQuery(quantityType: stairType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -102,7 +102,7 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
         // 데이터 소스 필터링을 위한 추가 조건
-        let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
+        let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in

--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -20,9 +20,8 @@ class HealthKitService: ObservableObject {
     @AppStorage("WeeklyFlightsClimbed", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var weeklyFlightsClimbed: Double = 0.0
     @AppStorage("TotalFlightsClimbedSinceAuthorization", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var TotalFlightsClimbedSinceAuthorization: Double = 0.0
     @AppStorage("LastFetchTime", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var LastFetchTime: String = ""
-    @AppStorage("authorizationDateKey", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var authorizationDateKey: String = ""
+    @AppStorage("HealthKitAuthorizationDate", store: UserDefaults(suiteName: "group.macmac.pratice.carot")) var authorizationDateKey: String = ""
     @AppStorage("HealthKitAuthorized") var isHealthKitAuthorized: Bool = false
-    @AppStorage("ReserButtonPressed") var reserButtonPressed: Bool = false
     
     
     
@@ -49,11 +48,12 @@ class HealthKitService: ObservableObject {
                 self?.fetchAllFlightsClimbedData()
                 // 권한 요청 날짜를 기록하는 로직
                 self?.storeAuthorizationDate()
+                self?.fetchAndSaveFlightsClimbedSinceButtonPress()
                 
                 // 권한 허용 후에만 데이터를 가져오는 로직 실행
                 self?.getWeeklyStairDataAndSave()
                 self?.fetchAndSaveFlightsClimbedSinceAuthorization()
-                self?.fetchAndSaveFlightsClimbedSinceButtonPress()
+                
             } else {
                 self?.isHealthKitAuthorized = false
                 //                self?.isHealthKitAuthorized = false
@@ -66,19 +66,12 @@ class HealthKitService: ObservableObject {
     // 권한 허용 날짜를 UserDefaults에 저장하는 함수
     private func storeAuthorizationDate() {
         let authorizationDateKey = "HealthKitAuthorizationDate"
+        let defaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
         
-        // UserDefaults에 날짜가 저장되어 있는지 확인
-        if UserDefaults.standard.object(forKey: authorizationDateKey) == nil {
+        if defaults?.object(forKey: authorizationDateKey) == nil {
             let currentDate = Date()
-            
-            // 권한 허용 날짜 저장
-            UserDefaults.standard.set(currentDate, forKey: authorizationDateKey)
+            defaults?.set(currentDate, forKey: authorizationDateKey)
             print("HealthKit 권한 허용 날짜를 \(currentDate)로 저장했습니다.")
-        } else {
-            // 이미 날짜가 저장된 경우, 기존 날짜를 사용
-            if UserDefaults.standard.object(forKey: authorizationDateKey) is Date {
-                //                print("이전에 저장된 HealthKit 권한 허용 날짜: \(savedDate)")
-            }
         }
     }
     
@@ -86,7 +79,14 @@ class HealthKitService: ObservableObject {
     
     // MARK: - 헬스킷 권한을 받은 당일 부터의 계단 오르기 데이터를 가져오는 기능
     func fetchAndSaveFlightsClimbedSinceAuthorization() {
-        guard let authorizationDate = UserDefaults.standard.object(forKey: "HealthKitAuthorizationDate") as? Date else {
+        // App Group UserDefaults를 사용
+        guard let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot") else {
+            print("App Group 저장소를 초기화하는 데 실패했습니다.")
+            return
+        }
+        
+        // 권한 허용 날짜 가져오기
+        guard let authorizationDate = appGroupDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date else {
             print("권한 허용 날짜가 설정되지 않았습니다.")
             return
         }
@@ -102,10 +102,8 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
         // 데이터 소스 필터링을 위한 추가 조건
-        // 사용자가 데이터를 주작했는지 아닌지 파악하는 부분 NSPredicate -> 메타 데이터 쿼리 조건, yes가 아닌 데이터만 가져 오겠다는 것.
         let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
-        
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in
             if let error = error {
@@ -124,10 +122,9 @@ class HealthKitService: ObservableObject {
             let currentFetchTime = Date()
             let formattedFetchTime = formatter.string(from: currentFetchTime)
             
-            // UserDefaults에 계단 데이터와 함께 패치 시각 저장
-            let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot")
-            appGroupDefaults?.set(totalFlightsClimbed, forKey: "TotalFlightsClimbedSinceAuthorization")
-            appGroupDefaults?.set(formattedFetchTime, forKey: "LastFetchTime") // 포맷된 패치 시각 저장
+            // App Group UserDefaults에 계단 데이터와 함께 패치 시각 저장
+            appGroupDefaults.set(totalFlightsClimbed, forKey: "TotalFlightsClimbedSinceAuthorization")
+            appGroupDefaults.set(formattedFetchTime, forKey: "LastFetchTime") // 포맷된 패치 시각 저장
             
             // 패치 결과를 콘솔에 출력
             print("총 계단 오르기 수 \(totalFlightsClimbed)를 저장했습니다. (패치 시각: \(formattedFetchTime))")
@@ -135,6 +132,7 @@ class HealthKitService: ObservableObject {
         
         healthStore.execute(query)
     }
+    
     
     // MARK: - 헬스킷 권한을 받았는지 아닌지를 확인하기 위해 전체 계단오르기 데이터를 호출해서 isHealthKitAuthorized를 업데이트하는 함수
     func fetchAllFlightsClimbedData() {
@@ -179,6 +177,7 @@ class HealthKitService: ObservableObject {
     
     
     // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
+    // MARK: - UserDefaults에 토-다음 금요일을 한주로 일주일 치 계단 오르기 수를 호출 및 앱스토리지에 저장하는 함수
     func getWeeklyStairDataAndSave() {
         if let stairType = HKObjectType.quantityType(forIdentifier: .flightsClimbed) {
             let calendar = Calendar.current
@@ -202,8 +201,14 @@ class HealthKitService: ObservableObject {
                 return
             }
             
+            // App Group UserDefaults 가져오기
+            guard let appGroupDefaults = UserDefaults(suiteName: "group.macmac.pratice.carot") else {
+                print("App Group 저장소를 초기화하는 데 실패했습니다.")
+                return
+            }
+            
             // 권한 허용 날짜 가져오기
-            guard let authorizationDate = UserDefaults.standard.object(forKey: "HealthKitAuthorizationDate") as? Date else {
+            guard let authorizationDate = appGroupDefaults.object(forKey: "HealthKitAuthorizationDate") as? Date else {
                 print("권한 허용 날짜가 설정되지 않았습니다.")
                 return
             }
@@ -225,7 +230,6 @@ class HealthKitService: ObservableObject {
             }
             
             // HealthKit 쿼리 실행
-            //            let adjustedStartDateMinusOneDay = Calendar.current.date(byAdding: .day, value: -1, to: adjustedStartDate)!
             let predicate = HKQuery.predicateForSamples(withStart: adjustedStartDate, end: endOfWeekDate, options: [])
             
             let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
@@ -241,28 +245,33 @@ class HealthKitService: ObservableObject {
                 }
                 
                 let totalFlightsClimbed = result?.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0.0
-                UserDefaults(suiteName: "group.macmac.pratice.carot")?.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
+                appGroupDefaults.set(totalFlightsClimbed, forKey: "WeeklyFlightsClimbed")
                 
                 DispatchQueue.main.async {
                     self.weeklyFlightsClimbed = totalFlightsClimbed
                 }
-                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 UserDefaults에 저장했습니다.")
+                print("주간 계단 수 (토-금): \(totalFlightsClimbed)를 App Group UserDefaults에 저장했습니다.")
                 print("Authorization Date: \(String(describing: authorizationDate)), Start: \(adjustedStartDate), End: \(endOfWeekDate)")
             }
             healthStore.execute(query)
         }
     }
     
+    
     // MARK: - 리셋 버튼을 누르면 현재 시간을 권한 허용 날짜로 대신하여 오늘 0시 부터의 데이터 패치 됨.
     func fetchAndSaveFlightsClimbedSinceButtonPress() {
         
         // 현재 시각을 버튼 누른 시각으로 저장 (HealthKitAuthorizationDate로 사용)
         let now = Date()
-        UserDefaults.standard.set(now, forKey: "HealthKitAuthorizationDate")
+        if let defaults = UserDefaults(suiteName: "group.macmac.pratice.carot") {
+            defaults.set(now, forKey: "HealthKitAuthorizationDate")
+        } else {
+            print("App Group 저장소를 초기화하는 데 실패했습니다.")
+        }
         
         fetchAndSaveFlightsClimbedSinceAuthorization()
-        
     }
+    
     
     
     

--- a/StepSquad/StepSquad/Resource/CollectedItems.swift
+++ b/StepSquad/StepSquad/Resource/CollectedItems.swift
@@ -54,4 +54,9 @@ class CollectedItems: Codable {
     func getSortedItemsNameList() -> [String] {
         return items.sorted { (first, second) in return first.value > second.value}.map(\.key)
     }
+    
+    func resetItems() {
+        items = [String: Date]()
+        save()
+    }
 }

--- a/StepSquad/StepSquad/Resource/CompletedLevels.swift
+++ b/StepSquad/StepSquad/Resource/CompletedLevels.swift
@@ -49,4 +49,9 @@ class CompletedLevels: Codable {
     func isCompleted(level: Int) -> Bool {
         return levels.keys.contains(level)
     }
+    
+    func resetLevels() {
+        levels = [Int: Date]()
+        save()
+    }
 }

--- a/StepSquad/StepSquad/Resource/CurrentStatusModel.swift
+++ b/StepSquad/StepSquad/Resource/CurrentStatusModel.swift
@@ -15,7 +15,7 @@ class CurrentStatus: Codable {
                 return levels[i]!
             }
         }
-        return levels[1]! // 에러 발생시 레벨 1으로 설정
+        return levels[20]! // 19레벨까지 달성했을 때 만렙
     }
     var currentProgress: Int { // 현재 레벨의 현재 단계
         let gap = (currentLevel.maxStaircase + 1) - currentLevel.minStaircase

--- a/StepSquad/StepSquad/Resource/LevelModel.swift
+++ b/StepSquad/StepSquad/Resource/LevelModel.swift
@@ -210,4 +210,14 @@ let levels: [Int: Level] = [
         difficulty: .impossible,
         wikiLink: "",
         achievementId: "hr24"),
+    // TODO: - 만렙 설정하기
+    20: Level(
+        level: 20,
+        minStaircase: 1440,
+        maxStaircase: Int.max,
+        item: "",
+        itemImage: "",
+        difficulty: .impossible,
+        wikiLink: "",
+        achievementId: "")
 ]

--- a/StepSquad/StepSquad/Resource/LevelModel.swift
+++ b/StepSquad/StepSquad/Resource/LevelModel.swift
@@ -214,7 +214,7 @@ let levels: [Int: Level] = [
     20: Level(
         level: 20,
         minStaircase: 1440,
-        maxStaircase: Int.max,
+        maxStaircase: Int.max - 1,
         item: "",
         itemImage: "",
         difficulty: .impossible,

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -586,6 +586,15 @@ struct MainViewPhase3: View {
         compareCurrentLevelAndUpdate()
         updateLeaderboard()
     }
+    
+    // MARK: 만렙 이후 리셋하기
+    func resetLevel() {
+        currentStatus.updateStaircase(0)
+        gameCenterManager.resetAchievements()
+        completedLevels.resetLevels()
+        // TODO: 오른 층계 데이터 패칭 시점 현재로 변경
+        // TODO: saveCurrentStatus() 작동 확인
+    }
 
     // MARK: Level 관련 테스트 프린트문
     func printAll() {

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -86,6 +86,10 @@ struct MainViewPhase3: View {
                         .padding(.horizontal, 36)
 
                         ScrollView {
+                            Button("Reset") {
+                                print("reset")
+                                resetLevel()
+                            }
                             VStack(spacing: 0) {
                                 if isHealthKitAuthorized {
                                     LevelUpView
@@ -444,6 +448,7 @@ struct MainViewPhase3: View {
         gameCenterManager.authenticateUser()
         // MARK: 저장된 레벨 정보 불러오고 헬스킷 정보로 업데이트하기
         currentStatus = loadCurrentStatus()
+        printAll()
     }
 
     // MARK: - 타이머
@@ -590,10 +595,12 @@ struct MainViewPhase3: View {
     // MARK: 만렙 이후 리셋하기
     func resetLevel() {
         currentStatus.updateStaircase(0)
+        saveCurrentStatus()
         gameCenterManager.resetAchievements()
         completedLevels.resetLevels()
         // TODO: 오른 층계 데이터 패칭 시점 현재로 변경
         // TODO: saveCurrentStatus() 작동 확인
+        printAll()
     }
 
     // MARK: Level 관련 테스트 프린트문

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -45,6 +45,10 @@ struct MainViewPhase3: View {
     }
     let electricBirdAchievementCount = UserDefaults.standard.integer(forKey: "electricBirdAchievementCount")
     
+    var isHighestLevel: Bool {
+        return currentStatus.currentLevel.level == 20
+    }
+    
     var body: some View {
         if isLaunching {
             SplashView()
@@ -349,17 +353,19 @@ struct MainViewPhase3: View {
                 MaterialsView(isMaterialSheetPresented: $isMaterialSheetPresented, isShowingNewItem: $isShowingNewItem, completedLevels: completedLevels, collectedItems: collectedItems)
             }
             // MARK: 임시 리셋 버튼
-            Button {
-                resetLevel()
-            } label: {
-                HStack() {
-                    Image(systemName: "leaf.fill")
-                    Text("리셋하기")
+            if isHighestLevel {
+                Button {
+                    resetLevel()
+                } label: {
+                    HStack() {
+                        Image(systemName: "leaf.fill")
+                        Text("리셋하기")
+                    }
+                    .padding(.vertical, 7)
+                    .padding(.horizontal, 14)
+                    .foregroundStyle(Color.white)
+                    .background(Color(hex: 0x864035), in: RoundedRectangle(cornerRadius: 30))
                 }
-                .padding(.vertical, 7)
-                .padding(.horizontal, 14)
-                .foregroundStyle(Color.white)
-                .background(Color(hex: 0x864035), in: RoundedRectangle(cornerRadius: 30))
             }
         }
         .onAppear {

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -204,6 +204,7 @@ struct MainViewPhase3: View {
                             service.getWeeklyStairDataAndSave()
                             service.fetchAndSaveFlightsClimbedSinceAuthorization()
                             updateLevelsAndGameCenter()
+                            printAll()
                         }
                         .scrollIndicators(ScrollIndicatorVisibility.hidden)
                         .onAppear {
@@ -596,10 +597,15 @@ struct MainViewPhase3: View {
     func resetLevel() {
         currentStatus.updateStaircase(0)
         saveCurrentStatus()
+        do {
+            try context.delete(model: StairStepModel.self)
+        } catch {
+            print("error: Failed to clear all StairStepModel data.")
+        }
         gameCenterManager.resetAchievements()
         completedLevels.resetLevels()
+        collectedItems.resetItems()
         // TODO: 오른 층계 데이터 패칭 시점 현재로 변경
-        // TODO: saveCurrentStatus() 작동 확인
         printAll()
     }
 
@@ -614,6 +620,7 @@ struct MainViewPhase3: View {
         print("현재 단계 이미지: \(currentStatus.progressImage)")
         print("사용자에게 보여준 마지막 달성 레벨: \(completedLevels.lastUpdatedLevel)")
         print("collected items: \(collectedItems.getSortedItemsNameList())")
+        print("nfc 태깅 횟수: \(stairSteps.count)")
     }
 }
 

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -204,7 +204,6 @@ struct MainViewPhase3: View {
                             service.getWeeklyStairDataAndSave()
                             service.fetchAndSaveFlightsClimbedSinceAuthorization()
                             updateLevelsAndGameCenter()
-                            printAll()
                         }
                         .scrollIndicators(ScrollIndicatorVisibility.hidden)
                         .onAppear {
@@ -464,7 +463,6 @@ struct MainViewPhase3: View {
         gameCenterManager.authenticateUser()
         // MARK: 저장된 레벨 정보 불러오고 헬스킷 정보로 업데이트하기
         currentStatus = loadCurrentStatus()
-        printAll()
     }
     
     // MARK: - 타이머
@@ -621,7 +619,6 @@ struct MainViewPhase3: View {
         completedLevels.resetLevels()
         collectedItems.resetItems()
         service.fetchAndSaveFlightsClimbedSinceButtonPress()
-        printAll()
     }
 
     // MARK: Level 관련 테스트 프린트문

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -86,10 +86,6 @@ struct MainViewPhase3: View {
                         .padding(.horizontal, 36)
                         
                         ScrollView {
-                            Button("Reset") {
-                                print("reset")
-                                resetLevel()
-                            }
                             VStack(spacing: 0) {
                                 if isHealthKitAuthorized {
                                     LevelUpView
@@ -354,7 +350,7 @@ struct MainViewPhase3: View {
             }
             // MARK: 임시 리셋 버튼
             Button {
-                service.fetchAndSaveFlightsClimbedSinceButtonPress()
+                resetLevel()
             } label: {
                 HStack() {
                     Image(systemName: "leaf.fill")
@@ -618,7 +614,7 @@ struct MainViewPhase3: View {
         gameCenterManager.resetAchievements()
         completedLevels.resetLevels()
         collectedItems.resetItems()
-        // TODO: 오른 층계 데이터 패칭 시점 현재로 변경
+        service.fetchAndSaveFlightsClimbedSinceButtonPress()
         printAll()
     }
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 레벨 19까지 달성하면 메인뷰에서 임시로 리셋하기 버튼을 띄운다.
- 리셋하기 버튼은 resetLevels()를 실행한다.
- resetLevels()로 사용자의 오른 층계 데이터 패칭 시점을 변경하며 0으로 설정하고, 달성 성취, 획득 재료, nfc 태깅 정보를 모두 지운다.
- 레벨 19 이후 사용자는 레벨 20(사실상 만렙)을 달성한다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #149 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->
