### PR TITLE
[#160] feature: phase5 환경 성취 달성 기능

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -97,7 +97,7 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfAuthorizationDate, end: Date(), options: [])
         
         // 사용자 입력 데이터를 제외한 조건 추가
-        let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
+        let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in

--- a/StepSquad/StepSquad/Helper/GameCenterManager.swift
+++ b/StepSquad/StepSquad/Helper/GameCenterManager.swift
@@ -121,11 +121,31 @@ class GameCenterManager: NSObject, GKGameCenterControllerDelegate, ObservableObj
     }
         
     // MARK: 성취 달성 여부 확인 후 성취 업데이트하기
-    func reportCompletedAchievement(achievementId: String) -> Bool {
+    func reportCompletedAchievement(achievementId: String){
+        guard isGameCenterLoggedIn else {
+            print("Error: user is not logged in to Game Center.")
+            return
+        }
+        let achievement = GKAchievement(identifier: achievementId)
+        if !achievement.isCompleted {
+            achievement.percentComplete = 100.0
+            achievement.showsCompletionBanner = true
+            GKAchievement.report([achievement], withCompletionHandler: {(error: Error?) in
+                guard error == nil else {
+                    print("Error: \(String(describing: error))")
+                    return
+                }
+                print("game center: \(achievement.identifier) achievement completed.")
+            })
+        }
+    }
+    
+    // MARK: 성취 달성 여부 확인 후 성취 업데이트하기, 달성 여부 반환
+    func reportCompletedAchievementWithReturn(achievementId: String) -> Bool {
         var isReported = false
         guard isGameCenterLoggedIn else {
             print("Error: user is not logged in to Game Center.")
-//            print("login isReported: \(isReported)")
+            print("login isReported: \(isReported)")
             return isReported
         }
         let achievement = GKAchievement(identifier: achievementId)
@@ -140,10 +160,10 @@ class GameCenterManager: NSObject, GKGameCenterControllerDelegate, ObservableObj
                 print("game center: \(achievement.identifier) achievement completed.")
                 isReported = true
             })
-//            print("after report isReported: \(isReported)")
+            print("after report isReported: \(isReported)")
             return isReported
         }
-//        print("login isReported: \(isReported)")
+        print("login isReported: \(isReported)")
         return isReported
     }
     

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -579,10 +579,11 @@ struct MainViewPhase3: View {
             }
         }
         if (currentStatus.getTotalStaircase() / 40) > electricBirdAchievementCount { // 누적 오른 층계가 40층의 배수라면,
-            //            print("It's \(currentStatus.getTotalStaircase() / 40)번째 틈새 전기 절약 성취")
-            if gameCenterManager.reportCompletedAchievement(achievementId: "electricBird") { // 성취를 정상적으로 받는다면,
-                UserDefaults.standard.setValue(currentStatus.getTotalStaircase() / 40, forKey: "electricBirdAchievementCount")
-            }
+            print("-----It's \(currentStatus.getTotalStaircase() / 40)번째 틈새 전기 절약 성취")
+//            if gameCenterManager.reportCompletedAchievement(achievementId: "electricBird") { // 성취를 정상적으로 받는다면,
+//                UserDefaults.standard.setValue(currentStatus.getTotalStaircase() / 40, forKey: "electricBirdAchievementCount")
+//                print("저장된 electricBirdAchievementCount: \(UserDefaults.standard.integer(forKey: "electricBirdAchievementCount"))")
+//            }
         }
     }
     

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -591,7 +591,7 @@ struct MainViewPhase3: View {
         }
     }
     
-    // MARK: 오프라인 환경에서 받지 못한 레벨, 입단증 성취 다시 주기
+    // MARK: 오프라인 환경에서 받지 못한 레벨, 입단증, 환경 관련 성취 다시 주기
     func reportMissedAchievement() {
         if isHealthKitAuthorized {
             gameCenterManager.reportCompletedAchievement(achievementId: "memberOfStepSquad")
@@ -599,6 +599,11 @@ struct MainViewPhase3: View {
         if completedLevels.lastUpdatedLevel >= 1 {
             for level in 1...completedLevels.lastUpdatedLevel {
                 gameCenterManager.reportCompletedAchievement(achievementId: levels[level]!.achievementId)
+            }
+        }
+        for i in [1, 10, 20, 36] {
+            if lastElectricAchievementCount >= i {
+                gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i != 1 ? String(i) : "")")
             }
         }
     }

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -43,7 +43,7 @@ struct MainViewPhase3: View {
             saveCurrentStatus()
         }
     }
-    let electricBirdAchievementCount = UserDefaults.standard.integer(forKey: "electricBirdAchievementCount")
+    @AppStorage("lastElectricAchievementCount") var lastElectricAchievementCount = 0
     
     var isHighestLevel: Bool {
         return currentStatus.currentLevel.level == 20
@@ -204,6 +204,7 @@ struct MainViewPhase3: View {
                             service.getWeeklyStairDataAndSave()
                             service.fetchAndSaveFlightsClimbedSinceAuthorization()
                             updateLevelsAndGameCenter()
+                            printAll()
                         }
                         .scrollIndicators(ScrollIndicatorVisibility.hidden)
                         .onAppear {
@@ -463,6 +464,7 @@ struct MainViewPhase3: View {
         gameCenterManager.authenticateUser()
         // MARK: 저장된 레벨 정보 불러오고 헬스킷 정보로 업데이트하기
         currentStatus = loadCurrentStatus()
+        printAll()
     }
     
     // MARK: - 타이머
@@ -578,12 +580,14 @@ struct MainViewPhase3: View {
                 gameCenterManager.reportCompletedAchievement(achievementId: levels[i]!.achievementId) // 해당 레벨의 성취 달성
             }
         }
-        if (currentStatus.getTotalStaircase() / 40) > electricBirdAchievementCount { // 누적 오른 층계가 40층의 배수라면,
-            print("-----It's \(currentStatus.getTotalStaircase() / 40)번째 틈새 전기 절약 성취")
-//            if gameCenterManager.reportCompletedAchievement(achievementId: "electricBird") { // 성취를 정상적으로 받는다면,
-//                UserDefaults.standard.setValue(currentStatus.getTotalStaircase() / 40, forKey: "electricBirdAchievementCount")
-//                print("저장된 electricBirdAchievementCount: \(UserDefaults.standard.integer(forKey: "electricBirdAchievementCount"))")
-//            }
+        for i in [1, 10, 20, 36] { // 40, 400, 800, 1440층에서 환경 성취 달성
+            if (currentStatus.getTotalStaircase() / 40) >= i { // 특정 층 이상으로 계단을 걸었다면,
+                if i > lastElectricAchievementCount { // 특정 층을 달성하고 성취를 아직 받지 않았다면,
+                    print("\(i)kWh 틈새 전기 절약 성취 달성")
+                    gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i != 1 ? String(i) : "")")
+                    lastElectricAchievementCount = i
+                }
+            }
         }
     }
     
@@ -632,6 +636,7 @@ struct MainViewPhase3: View {
         print("현재 단계: \(currentStatus.currentProgress)")
         print("현재 단계 이미지: \(currentStatus.progressImage)")
         print("사용자에게 보여준 마지막 달성 레벨: \(completedLevels.lastUpdatedLevel)")
+        print("마지막으로 달성한 환경 성취: \(lastElectricAchievementCount)kWh")
         print("collected items: \(collectedItems.getSortedItemsNameList())")
         print("nfc 태깅 횟수: \(stairSteps.count)")
     }

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -43,7 +43,7 @@ struct MainViewPhase3: View {
             saveCurrentStatus()
         }
     }
-    @AppStorage("lastElectricAchievementCount") var lastElectricAchievementCount = 0
+    @AppStorage("lastElectricAchievementKwh") var lastElectricAchievementKwh = 0
     
     var isHighestLevel: Bool {
         return currentStatus.currentLevel.level == 20
@@ -582,10 +582,10 @@ struct MainViewPhase3: View {
         }
         for i in [1, 10, 20, 36] { // 40, 400, 800, 1440층에서 환경 성취 달성
             if (currentStatus.getTotalStaircase() / 40) >= i { // 특정 층 이상으로 계단을 걸었다면,
-                if i > lastElectricAchievementCount { // 특정 층을 달성하고 성취를 아직 받지 않았다면,
+                if i > lastElectricAchievementKwh { // 특정 층을 달성하고 성취를 아직 받지 않았다면,
                     print("\(i)kWh 틈새 전기 절약 성취 달성")
-                    gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i != 1 ? String(i) : "")")
-                    lastElectricAchievementCount = i
+                    gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i)")
+                    lastElectricAchievementKwh = i
                 }
             }
         }
@@ -602,8 +602,8 @@ struct MainViewPhase3: View {
             }
         }
         for i in [1, 10, 20, 36] {
-            if lastElectricAchievementCount >= i {
-                gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i != 1 ? String(i) : "")")
+            if lastElectricAchievementKwh >= i {
+                gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i)")
             }
         }
     }
@@ -641,7 +641,7 @@ struct MainViewPhase3: View {
         print("현재 단계: \(currentStatus.currentProgress)")
         print("현재 단계 이미지: \(currentStatus.progressImage)")
         print("사용자에게 보여준 마지막 달성 레벨: \(completedLevels.lastUpdatedLevel)")
-        print("마지막으로 달성한 환경 성취: \(lastElectricAchievementCount)kWh")
+        print("마지막으로 달성한 환경 성취: \(lastElectricAchievementKwh)kWh")
         print("collected items: \(collectedItems.getSortedItemsNameList())")
         print("nfc 태깅 횟수: \(stairSteps.count)")
     }

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -204,7 +204,6 @@ struct MainViewPhase3: View {
                             service.getWeeklyStairDataAndSave()
                             service.fetchAndSaveFlightsClimbedSinceAuthorization()
                             updateLevelsAndGameCenter()
-                            printAll()
                         }
                         .scrollIndicators(ScrollIndicatorVisibility.hidden)
                         .onAppear {
@@ -464,7 +463,6 @@ struct MainViewPhase3: View {
         gameCenterManager.authenticateUser()
         // MARK: 저장된 레벨 정보 불러오고 헬스킷 정보로 업데이트하기
         currentStatus = loadCurrentStatus()
-        printAll()
     }
     
     // MARK: - 타이머
@@ -583,7 +581,7 @@ struct MainViewPhase3: View {
         for i in [1, 10, 20, 36] { // 40, 400, 800, 1440층에서 환경 성취 달성
             if (currentStatus.getTotalStaircase() / 40) >= i { // 특정 층 이상으로 계단을 걸었다면,
                 if i > lastElectricAchievementKwh { // 특정 층을 달성하고 성취를 아직 받지 않았다면,
-                    print("\(i)kWh 틈새 전기 절약 성취 달성")
+//                    print("\(i)kWh 틈새 전기 절약 성취 달성")
                     gameCenterManager.reportCompletedAchievement(achievementId: "electricBird\(i)")
                     lastElectricAchievementKwh = i
                 }

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -620,6 +620,7 @@ struct MainViewPhase3: View {
     func resetLevel() {
         currentStatus.updateStaircase(0)
         saveCurrentStatus()
+        lastElectricAchievementKwh = 0
         do {
             try context.delete(model: StairStepModel.self)
         } catch {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 기존의 환경 성취 에러를 파악하고 삭제했습니다. 
- 새로운 환경 성취를 달성할 수 있도록 설정했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #160 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 기존 환경 성취 에러: 뱃지 달성 여부에 따라 return 값을 지니게 했었는데, 메인뷰와 게임센터의 함수 실행 싱크가 같지 않아서 계속 오류라고 파악함. 그래서 달성하지 않은 것이라고 생각하고 될 때마다 계속 뱃지를 준 것임.
- 새로운 환경 성취: 40, 400, 800, 1440층에서 해당 성취를 달성함, 층수에 따라 주는 약재처럼 '달성 뱃지' 버튼을 누르면 다시 줌, 리셋 이후 1회차처럼 획득할 수 있음 .
- 새로 업데이트 할 때 electricBird 성취는 archive하고, electricBird1 ~ 36을 제공할 예정.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->
