### PR TITLE
[#179] 데이터 파라미터 전달 및 입단증에 들어가는 배열 역순

### DIFF
--- a/StepSquad/StepSquad.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StepSquad/StepSquad.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c0bbce475ab2f78b4c40b28111fcbb3a4bc056a148c7011a688004bacc3993b",
+  "originHash" : "1b3282c1ee161570ad0d503c372793ad92013f644443df6064e51eaed1d9b530",
   "pins" : [
     {
       "identity" : "effects-library",

--- a/StepSquad/StepSquad/View/CustomTableView.swift
+++ b/StepSquad/StepSquad/View/CustomTableView.swift
@@ -64,7 +64,7 @@ struct CustomTableView: View {
                 .border(Color(hex: 0xDBEED0), width: 0.5)
             } else {
                 // Data Rows
-                ForEach(manager.records, id: \.id) { record in
+                ForEach(Array(manager.records.reversed()), id: \.id) { record in
                     HStack(spacing: 0) {
                         // 회차
                         Text("\(record.round)")

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -737,15 +737,6 @@ struct ResetNavigationView: View {
                 .frame(width: 256)
                 .padding(.top, 32)
             
-            
-            // 최근 기록 표시
-            if let latestRecord = manager.records.last {
-                VStack {
-                    Text("\(Int(latestRecord.floorsClimbed))층")
-                    Text("D-Day: \(latestRecord.dDay)")
-                }
-            }
-            
             Spacer()
             
             NavigationLink(destination: DetailView(isResetViewPresented: $isResetViewPresented)) {
@@ -895,7 +886,6 @@ struct DetailView2: View {
 // MARK: - 4번 째 뷰 (입력창)
 struct DetailView3: View {
     @Environment(\.modelContext) var context
-    
     @StateObject private var manager = ClimbingManager()
     
     @Binding var isResetViewPresented: Bool
@@ -910,7 +900,6 @@ struct DetailView3: View {
     var body: some View {
         VStack {
             VStack(spacing: 16) {
-                
                 Text("")
                     .font(.system(size: 12))
                     .foregroundColor(.white)
@@ -920,18 +909,17 @@ struct DetailView3: View {
                     .multilineTextAlignment(.center)
                     .font(.title)
                     .fontWeight(.bold)
+                
                 VStack {
                     Text("진행하려면 ") +
                     Text("‘\(correctText)’")
                         .foregroundColor(Color.primaryColor) +
                     Text("를 입력하세요.")
-                    
                 }
                 .multilineTextAlignment(.center)
                 .font(.body)
             }
             .padding(.top, 36)
-            
             
             TextField("건강해라", text: $userInput)
                 .padding()
@@ -947,7 +935,6 @@ struct DetailView3: View {
                     Text(errorMessage)
                         .foregroundColor(.red)
                         .font(.caption2)
-                    
                 }
                 Text("달성 뱃지, 약재, 리더보드 점수는 영구적으로 사라집니다.\n하산 기록(날짜, 횟수)는 입단증을 통해 확인할 수 있습니다.")
                     .font(.caption2)
@@ -957,30 +944,14 @@ struct DetailView3: View {
             
             Spacer()
             
-            NavigationLink(destination: ShowNewBirdView(isShowNewBirdPresented: $isResetViewPresented, days: 123, stairs: 1444)
-                .navigationBarHidden(true)
-                .onAppear {
-                    
-//                    // MARK: 순위표로 이동 입력창에 오타 없이 사용자가 입력하면 자동으로 실행되는 함수들
-//                    
-                    // 1. 날짜 리셋 함수
-                    service.fetchAndSaveFlightsClimbedSinceButtonPress()
-                    
-                    // 2. 하산 날짜, 계단 오른 층수, dDAY, 회차 더하기 함수
-                    let floorsClimbed = service.getSavedFlightsClimbedFromDefaults()
-                    let dDay = loadDDayFromDefaults()
-                    
-                    manager.addRecord(descentDate: Date(), floorsClimbed: Float(floorsClimbed), dDay: Int(dDay))
-                    
-                    // 3. 현재 레벨, 획득 재료, nfc 태깅 정보, 성취 관련 리셋
-                    MainViewPhase3().resetLevel()
-                    do {
-                        try context.delete(model: StairStepModel.self)
-                    } catch {
-                        print("error: Failed to clear all StairStepModel data.")
-                    }
-                    
-                }) {
+            if let latestRecord = manager.records.last {
+                NavigationLink(
+                    destination: ShowNewBirdView(
+                        isShowNewBirdPresented: $isResetViewPresented,
+                        days: latestRecord.dDay,
+                        stairs: Int(latestRecord.floorsClimbed)
+                    )
+                ) {
                     Text("하산하기")
                         .padding()
                         .frame(width: 352, height: 50)
@@ -990,6 +961,7 @@ struct DetailView3: View {
                 }
                 .disabled(userInput != correctText)
                 .padding(.top)
+            }
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -1002,11 +974,31 @@ struct DetailView3: View {
                 }
             }
         }
-        .onChange(of: userInput) { newValue in
-            if newValue != correctText {
-                errorMessage = "틈새에게 마지막으로 덕담인 ‘건강해라'를 입력해주세요."
-            } else {
-                errorMessage = ""
+        //        .onChange(of: userInput) { newValue in
+        //            if newValue != correctText {
+        //                errorMessage = "틈새에게 마지막으로 덕담인 ‘건강해라'를 입력해주세요."
+        //            } else {
+        //                errorMessage = ""
+        //            }
+        //        }
+        .onAppear {
+            // MARK: 순위표로 이동 입력창에 오타 없이 사용자가 입력하면 자동으로 실행되는 함수들
+            
+            // 1. 날짜 리셋 함수
+            service.fetchAndSaveFlightsClimbedSinceButtonPress()
+            
+            // 2. 하산 날짜, 계단 오른 층수, dDAY, 회차 더하기 함수
+            let dDay = loadDDayFromDefaults()
+            let floorsClimbed = service.getSavedFlightsClimbedFromDefaults()
+            
+            manager.addRecord(descentDate: Date(), floorsClimbed: Float(floorsClimbed), dDay: Int(dDay))
+            
+            // 3. 현재 레벨, 획득 재료, NFC 태깅 정보, 성취 관련 리셋
+            MainViewPhase3().resetLevel()
+            do {
+                try context.delete(model: StairStepModel.self)
+            } catch {
+                print("error: Failed to clear all StairStepModel data.")
             }
         }
     }


### PR DESCRIPTION
## 📌 Summary
1. 데이터 파라미터 전달 
2. 입단증에 들어가는 배열 역순으로 


## ✍️ Description
- 이슈 티켓 : resolved #179 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
바로 reversed() 메서드를 쓰려고 했으나, ArraySlice를 반환하므로, .reversed() 뒤에 .map { $0 }을 붙이거나 Array()로 감싸서 Array로 반환함.

ArraySlice의 특징
1. 메모리 효율적
ArraySlice는 원본 배열을 복사하지 않고 같은 메모리 주소를 참조함.
그래서 새로운 배열을 생성하는 것보다 성능이 좋다.
하지만, ArraySlice를 직접 저장하거나, 특정 위치에서 요소를 가져오는 건 조심해야 함.

2. 인덱스 유지됨
ArraySlice는 원본 배열과 같은 인덱스를 유지함. 즉, arr[3...]로 ArraySlice를 만들면 0부터 시작하는 게 아니라, 3부터 시작하는 배열이 됌.
이 때문에 ArraySlice를 Array로 변환하지 않으면 예상치 못한 인덱스 오류가 날 수도 있다.

즉, 나는 데이터가 역순으로 된 새로운 배열이 가진 새로운 인덱스가 필요할 것이라 예상되므로 새 배열을 만들기로 선택함.

## 📚 Reference 
<img width="445" alt="스크린샷 2025-01-30 오후 6 20 41" src="https://github.com/user-attachments/assets/59ad7387-1d73-4f84-9d77-d969e8cb7624" />



## 🔥 Test

