### PR TITLE
[#181] feature: 오프라인 환경에서 게임센터 로그인이 되지 않은 경우 하산하기를 막기

### DIFF
--- a/StepSquad/StepSquad/HealthKit.swift
+++ b/StepSquad/StepSquad/HealthKit.swift
@@ -167,7 +167,7 @@ class HealthKitService: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: nil, end: nil, options: [])
         
         // 사용자가 입력한 데이터 제외 조건 추가 (선택 사항)
-        let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
+        let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
         let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
         
         let query = HKStatisticsQuery(quantityType: flightsClimbedType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { [weak self] _, result, error in
@@ -249,7 +249,7 @@ class HealthKitService: ObservableObject {
             //            let adjustedStartDateMinusOneDay = Calendar.current.date(byAdding: .day, value: -1, to: adjustedStartDate)!
             let predicate = HKQuery.predicateForSamples(withStart: adjustedStartDate, end: endOfWeekDate, options: [])
             
-            let userEnteredPredicate = NSPredicate(format: "metadata.%K != YES", HKMetadataKeyWasUserEntered)
+            let userEnteredPredicate = NSPredicate(format: "metadata.%K != NO", HKMetadataKeyWasUserEntered)
             let combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, userEnteredPredicate])
             
             let query = HKStatisticsQuery(quantityType: stairType, quantitySamplePredicate: combinedPredicate, options: .cumulativeSum) { _, result, error in

--- a/StepSquad/StepSquad/Helper/GameCenterManager.swift
+++ b/StepSquad/StepSquad/Helper/GameCenterManager.swift
@@ -14,13 +14,20 @@ class GameCenterManager: NSObject, GKGameCenterControllerDelegate, ObservableObj
     
     // MARK: 게임 센터 계정 인증하기
     func authenticateUser() {
+        var isErrorOccurred = false
         GKLocalPlayer.local.authenticateHandler = { vc, error in
             guard error == nil else {
                 print(error?.localizedDescription ?? "")
+                isErrorOccurred = true
                 return
             }
-            self.isGameCenterLoggedIn = true
-            print("game center: authenticated user")
+            if isErrorOccurred {
+                self.isGameCenterLoggedIn = false
+                print("game center: not authenticated user")
+            } else {
+                self.isGameCenterLoggedIn = true
+                print("game center: authenticated user")
+            }
         }
     }
     
@@ -121,7 +128,7 @@ class GameCenterManager: NSObject, GKGameCenterControllerDelegate, ObservableObj
     }
         
     // MARK: 성취 달성 여부 확인 후 성취 업데이트하기
-    func reportCompletedAchievement(achievementId: String){
+    func reportCompletedAchievement(achievementId: String) {
         guard isGameCenterLoggedIn else {
             print("Error: user is not logged in to Game Center.")
             return

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -240,7 +240,7 @@ struct MainViewPhase3: View {
                             service.getWeeklyStairDataAndSave()
                             service.fetchAndSaveFlightsClimbedSinceAuthorization()
                             updateLevelsAndGameCenter()
-                            printAll()
+//                            printAll()
                         }
                         .scrollIndicators(ScrollIndicatorVisibility.hidden)
                         .onAppear {
@@ -530,7 +530,7 @@ struct MainViewPhase3: View {
         gameCenterManager.authenticateUser()
         // MARK: 저장된 레벨 정보 불러오고 헬스킷 정보로 업데이트하기
         currentStatus = loadCurrentStatus()
-        printAll()
+//        printAll()
     }
     
     // MARK: - 타이머
@@ -684,14 +684,13 @@ struct MainViewPhase3: View {
     
     // MARK: 만렙 이후 리셋하기
     func resetLevel() {
-        print("--------resetLevel--------")
         currentStatus.updateStaircase(0)
         saveCurrentStatus()
         lastElectricAchievementKwh = 0
         gameCenterManager.resetAchievements()
         completedLevels.resetLevels()
         collectedItems.resetItems()
-        printAll()
+//        printAll()
     }
     
     // MARK: Level 관련 테스트 프린트문

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -23,6 +23,7 @@ struct MainViewPhase3: View {
     
     @State private var isResetViewPresented = false
     @State private var isShowNewBirdPresented = false
+    @State private var isWifiAlertPresented = false
     
     @State var userProfileImage: Image?
     
@@ -337,7 +338,11 @@ struct MainViewPhase3: View {
                 
                 // MARK: 만렙일 때 보여주는 리셋 버튼
                 Button {
-                    isResetViewPresented = true
+                    if gameCenterManager.isGameCenterLoggedIn {
+                        isResetViewPresented = true
+                    } else {
+                        isWifiAlertPresented = true
+                    }
                 } label: {
                     HStack() {
                         
@@ -350,6 +355,13 @@ struct MainViewPhase3: View {
                     .background(Color(hex: 0x864035), in: RoundedRectangle(cornerRadius: 30))
                 }
                 .padding(.top, 10)
+                .alert("네트워크 연결 상태를 확인한 후 앱에 다시 접속해주세요.", isPresented: $isWifiAlertPresented) {
+                    Button("확인") {
+                        isWifiAlertPresented = false
+                    }
+                } message: {
+                    Text("틈새는 온라인 환경에서만 하산을 할 수 있어요!")
+                }
                 
                 Spacer()
             } else {

--- a/StepSquad/StepSquad/View/ShowNewBirdView.swift
+++ b/StepSquad/StepSquad/View/ShowNewBirdView.swift
@@ -96,6 +96,7 @@ struct ItemsConfettiView: View {
                                 intensity: .low
                             )
             )
+            LinearGradient(colors: [.white, .white,  .clear], startPoint: .top, endPoint: .center)
             VStack {
                 VStack {
                     HStack(spacing: 0) {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 오프라인 환경으로 앱에 접속해서 게임 센터 로그인이 되지 않은 경우 하산하기 버튼을 눌렀을 때 alert이 뜨면서 하산하기를 진행할 수 없게 합니다.
- 테스트로 주작 오른 층수를 허용해두었었는데, 업데이트 전에 불허용으로 설정했습니다.
- ShowNewBirdView의 컨페티로 인해 텍스트가 가리지 않도록 흰 그라디언트 배경을 설정했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #181 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->
