### PR TITLE
[#191] feature: GPSStaircase 추가, collectedItems와 관계 설정

### DIFF
--- a/StepSquad/StepSquad.xcodeproj/project.pbxproj
+++ b/StepSquad/StepSquad.xcodeproj/project.pbxproj
@@ -333,9 +333,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadStickers/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadStickers;
@@ -345,6 +347,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadStickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = imessageStickerExtension;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -360,9 +363,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadStickers/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadStickers;
@@ -372,6 +377,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadStickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = imessageStickerExtension;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -508,10 +514,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = StepSquad.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2.1;
 				DEVELOPMENT_ASSET_PATHS = "\"StepSquad/Preview Content\"";
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StepSquad-Info.plist";
@@ -534,6 +542,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepSquadApp;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -551,10 +560,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = StepSquad.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2.1;
 				DEVELOPMENT_ASSET_PATHS = "\"StepSquad/Preview Content\"";
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "StepSquad-Info.plist";
@@ -577,6 +588,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepSquadApp;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -594,9 +606,11 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = StepSquadWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadWidget;
@@ -612,6 +626,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepsQuadAppWidget;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -630,9 +645,11 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = StepSquadWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2.1;
-				DEVELOPMENT_TEAM = AZ7B294WMJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AZ7B294WMJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StepSquadWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StepSquadWidget;
@@ -648,6 +665,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.45SeekDance.2024.StepSquadWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = stepsQuadAppWidget;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/StepSquad/StepSquad/Resource/CollectedItems.swift
+++ b/StepSquad/StepSquad/Resource/CollectedItems.swift
@@ -27,6 +27,11 @@ class CollectedItems: Codable {
         save()
     }
     
+    func deleteItem(item: String) {
+        items.removeValue(forKey: item)
+        save()
+    }
+    
     func save() {
         do {
             let data = try JSONEncoder().encode(items)

--- a/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
@@ -47,6 +47,6 @@ class GPSStaircase: Codable, Identifiable {
     }
 }
 
-let localStaircases: [GPSStaircase] = [
+let gpsStaircases: [GPSStaircase] = [
     GPSStaircase(id: "Test1", name: "초량 이바구길 168 계단", title: "역사가 오래된 초량의 이바구 길", steps: 168, latitude: 35.117143, longitude: 129.035298, province: .gyeongnam, description: "이바구길을 이바구를 떨며 걸어올라가 볼까나?", verificationLocation: "인증 장소 예시", reward: "국밥 육수", achievementId: "test1"),
 ]

--- a/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
@@ -48,5 +48,5 @@ class GPSStaircase: Codable, Identifiable {
 }
 
 let localStaircases: [GPSStaircase] = [
-//    GPSStaircase(id: "Test1", name: "동네 계단", title: "우리 동네에 이런 계단이 있다고?", steps: 70, latitude: <#T##Double#>, province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장한 선물", achievementId: "test1"),
+    GPSStaircase(id: "Test1", name: "초량 이바구길 168 계단", title: "역사가 오래된 초량의 이바구 길", steps: 168, latitude: 35.117143, longitude: 129.035298, province: .gyeongnam, description: "이바구길을 이바구를 떨며 걸어올라가 볼까나?", verificationLocation: "인증 장소 예시", reward: "국밥 육수", achievementId: "test1"),
 ]

--- a/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
@@ -19,7 +19,7 @@ enum KoreanProvince: String, Codable {
     case chungbuk = "충북"
 }
 
-class Staircase: Codable, Identifiable {
+class GPSStaircase: Codable, Identifiable {
     let id: String // TODO: id는 영문명으로 계단 이미지도 id와 동일하게 설정
     let name: String
     let title: String
@@ -45,7 +45,7 @@ class Staircase: Codable, Identifiable {
     }
 }
 
-let localStaircases: [Staircase] = [
-    Staircase(id: "Test1", name: "동네 계단", title: "우리 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장한 선물", achievementId: "test1"),
-    Staircase(id: "Test2", name: "먼 계단", title: "먼 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장히 선물", achievementId: "test2"),
+let localStaircases: [GPSStaircase] = [
+    GPSStaircase(id: "Test1", name: "동네 계단", title: "우리 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장한 선물", achievementId: "test1"),
+    GPSStaircase(id: "Test2", name: "먼 계단", title: "먼 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장히 선물", achievementId: "test2"),
 ]

--- a/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/GPSStaircaseModel.swift
@@ -20,32 +20,33 @@ enum KoreanProvince: String, Codable {
 }
 
 class GPSStaircase: Codable, Identifiable {
-    let id: String // TODO: id는 영문명으로 계단 이미지도 id와 동일하게 설정
-    let name: String
-    let title: String
-    let steps: Int
-    let locationX: Int // TODO: 인증방식에 따라 Location으로 변경
-    let locationY: Int
-    let province: KoreanProvince
-    let description: String
-    let reward: String // TODO: 리워드 이미지 파일명은 "[id]_reward"로 설정
+    let id: String // 영문명 TODO: 계단 이미지도 id와 동일하게 설정
+    let name: String // 계단명
+    let title: String // 계단의 부제
+    let steps: Int // 계단 개수
+    let latitude: Double // 위도
+    let longitude: Double // 경도
+    let province: KoreanProvince // 해당 지역
+    let description: String // 설명
+    let verificationLocation: String // 인증 위치 TODO: 인증 위치 파일명은 "[id]_location"
+    let reward: String // 획득 재료 TODO: 리워드 이미지 파일명은 "[id]_reward"로 설정
     let achievementId: String
     
-    init(id: String, name: String, title: String, steps: Int, location: (Int, Int), province: KoreanProvince, description: String, reward: String, achievementId: String) {
+    init(id: String, name: String, title: String, steps: Int, latitude: Double, longitude: Double, province: KoreanProvince, description: String, verificationLocation: String, reward: String, achievementId: String) {
         self.id = id
         self.name = name
         self.title = title
         self.steps = steps
-        self.locationX = location.0
-        self.locationY = location.1
+        self.latitude = latitude
+        self.longitude = longitude
         self.province = province
         self.description = description
+        self.verificationLocation = verificationLocation
         self.reward = reward
         self.achievementId = achievementId
     }
 }
 
 let localStaircases: [GPSStaircase] = [
-    GPSStaircase(id: "Test1", name: "동네 계단", title: "우리 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장한 선물", achievementId: "test1"),
-    GPSStaircase(id: "Test2", name: "먼 계단", title: "먼 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장히 선물", achievementId: "test2"),
+//    GPSStaircase(id: "Test1", name: "동네 계단", title: "우리 동네에 이런 계단이 있다고?", steps: 70, latitude: <#T##Double#>, province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장한 선물", achievementId: "test1"),
 ]

--- a/StepSquad/StepSquad/Resource/ItemModel.swift
+++ b/StepSquad/StepSquad/Resource/ItemModel.swift
@@ -36,4 +36,16 @@ let hiddenItems: [String: Item] = [
         itemColor: 0x03787B,
         achievementId: "clover",
         keyword: "퀘스트"),
+    "Test1": Item(
+        item: "가까운 동네 보상",
+        itemImage: "Clover",
+        itemColor: 0x03787B,
+        achievementId: "test1",
+        keyword: "계단 정복"),
+    "Test2": Item(
+        item: "먼 동네 보상",
+        itemImage: "Clover",
+        itemColor: 0x03787B,
+        achievementId: "test2",
+        keyword: "계단 정복"),
 ]

--- a/StepSquad/StepSquad/Resource/ItemModel.swift
+++ b/StepSquad/StepSquad/Resource/ItemModel.swift
@@ -37,15 +37,9 @@ let hiddenItems: [String: Item] = [
         achievementId: "clover",
         keyword: "퀘스트"),
     "Test1": Item(
-        item: "가까운 동네 보상",
+        item: "국밥 육수",
         itemImage: "Clover",
-        itemColor: 0x03787B,
+        itemColor: 0x7B4703,
         achievementId: "test1",
-        keyword: "계단 정복"),
-    "Test2": Item(
-        item: "먼 동네 보상",
-        itemImage: "Clover",
-        itemColor: 0x03787B,
-        achievementId: "test2",
         keyword: "계단 정복"),
 ]

--- a/StepSquad/StepSquad/Resource/StaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/StaircaseModel.swift
@@ -7,6 +7,18 @@
 
 import Foundation
 
+enum KoreanProvince: String, Codable {
+    case gangwon = "강원특별자치도"
+    case gyeonggi = "경기도"
+    case gyeongnam = "경상남도"
+    case gyeongbuk = "경상북도"
+    case jeonnam = "전라남도"
+    case jeonbuk = "전북특별자치도"
+    case jeju = "제주특별자치도"
+    case chungnam = "충청남도"
+    case chungbuk = "충청북도"
+}
+
 class Staircase: Codable {
     let id: String // TODO: id는 영문명으로 계단 이미지도 id와 동일하게 설정
     let name: String
@@ -14,17 +26,19 @@ class Staircase: Codable {
     let steps: Int
     let locationX: Int // TODO: 인증방식에 따라 Location으로 변경
     let locationY: Int
+    let province: KoreanProvince
     let description: String
     let reward: String // TODO: 리워드 이미지 파일명은 "[id]_reward"로 설정
     let achievementId: String
     
-    init(id: String, name: String, title: String, steps: Int, location: (Int, Int), description: String, reward: String, achievementId: String) {
+    init(id: String, name: String, title: String, steps: Int, location: (Int, Int), province: KoreanProvince, description: String, reward: String, achievementId: String) {
         self.id = id
         self.name = name
         self.title = title
         self.steps = steps
         self.locationX = location.0
         self.locationY = location.1
+        self.province = province
         self.description = description
         self.reward = reward
         self.achievementId = achievementId

--- a/StepSquad/StepSquad/Resource/StaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/StaircaseModel.swift
@@ -19,7 +19,7 @@ enum KoreanProvince: String, Codable {
     case chungbuk = "충청북도"
 }
 
-class Staircase: Codable {
+class Staircase: Codable, Identifiable {
     let id: String // TODO: id는 영문명으로 계단 이미지도 id와 동일하게 설정
     let name: String
     let title: String
@@ -44,3 +44,8 @@ class Staircase: Codable {
         self.achievementId = achievementId
     }
 }
+
+let localStaircases: [Staircase] = [
+    Staircase(id: "Test1", name: "동네 계단", title: "우리 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장한 선물", achievementId: "test1"),
+    Staircase(id: "Test2", name: "먼 계단", title: "먼 동네에 이런 계단이 있다고?", steps: 70, location: (1, 2), province: .jeju, description: "네 있습니다. 참고 설명입니다.", reward: "굉장히 선물", achievementId: "test2"),
+]

--- a/StepSquad/StepSquad/Resource/StaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/StaircaseModel.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 enum KoreanProvince: String, Codable {
-    case gangwon = "강원특별자치도"
-    case gyeonggi = "경기도"
-    case gyeongnam = "경상남도"
-    case gyeongbuk = "경상북도"
-    case jeonnam = "전라남도"
-    case jeonbuk = "전북특별자치도"
-    case jeju = "제주특별자치도"
-    case chungnam = "충청남도"
-    case chungbuk = "충청북도"
+    case gangwon = "강원"
+    case gyeonggi = "수도권"
+    case gyeongnam = "부산/울산/경남"
+    case gyeongbuk = "대구/경북"
+    case jeonnam = "광주/전남"
+    case jeonbuk = "전북"
+    case jeju = "제주"
+    case chungnam = "대전/충남"
+    case chungbuk = "충북"
 }
 
 class Staircase: Codable, Identifiable {

--- a/StepSquad/StepSquad/Resource/StaircaseModel.swift
+++ b/StepSquad/StepSquad/Resource/StaircaseModel.swift
@@ -1,0 +1,32 @@
+//
+//  StaircaseModel.swift
+//  StepSquad
+//
+//  Created by Groo on 2/20/25.
+//
+
+import Foundation
+
+class Staircase: Codable {
+    let id: String // TODO: id는 영문명으로 계단 이미지도 id와 동일하게 설정
+    let name: String
+    let title: String
+    let steps: Int
+    let locationX: Int // TODO: 인증방식에 따라 Location으로 변경
+    let locationY: Int
+    let description: String
+    let reward: String // TODO: 리워드 이미지 파일명은 "[id]_reward"로 설정
+    let achievementId: String
+    
+    init(id: String, name: String, title: String, steps: Int, location: (Int, Int), description: String, reward: String, achievementId: String) {
+        self.id = id
+        self.name = name
+        self.title = title
+        self.steps = steps
+        self.locationX = location.0
+        self.locationY = location.1
+        self.description = description
+        self.reward = reward
+        self.achievementId = achievementId
+    }
+}

--- a/StepSquad/StepSquad/View/MainViewPhase3.swift
+++ b/StepSquad/StepSquad/View/MainViewPhase3.swift
@@ -88,6 +88,14 @@ struct MainViewPhase3: View {
                                     .padding(5)
                                     .background(.grey100, in: Circle.circle)
                             }
+                            NavigationLink(destination: TestLocalStaircaseVerification(collectedItems: $collectedItems)) {
+                                Image(systemName: "chevron.right")
+                                    .resizable()
+                                    .frame(width: 22, height: 22)
+                                    .foregroundStyle(.primary)
+                                    .padding(5)
+                                    .background(.primary, in: Circle.circle)
+                            }
                         }
                         .padding(.top, 72)
                         .padding(.bottom, 4)

--- a/StepSquad/StepSquad/View/TestLocalStaircaseVerification.swift
+++ b/StepSquad/StepSquad/View/TestLocalStaircaseVerification.swift
@@ -11,23 +11,23 @@ struct TestLocalStaircaseVerification: View {
     @Binding var collectedItems: CollectedItems
     var body: some View {
         List {
-            ForEach(localStaircases) { localStaircase in
+            ForEach(gpsStaircases) { gpsStaircase in
                 Button(action: {
                     // TODO: 인증 완료 후 획득 재료에 추가하고, 게임센터 성취로 전달, 리스트에서 뷰 변경 필요
-                    if collectedItems.isCollected(item: localStaircase.id) {
-                        collectedItems.deleteItem(item: localStaircase.id)
+                    if collectedItems.isCollected(item: gpsStaircase.id) {
+                        collectedItems.deleteItem(item: gpsStaircase.id)
                     } else {
-                        collectedItems.collectItem(item: localStaircase.id, collectedDate: Date.now)
+                        collectedItems.collectItem(item: gpsStaircase.id, collectedDate: Date.now)
                     }
                 }, label: {
                     HStack {
-                        Text(localStaircase.name)
+                        Text(gpsStaircase.name)
                         Spacer()
-                        Text(collectedItems.isCollected(item: localStaircase.id) ? "정복 완료" : "정복 대기")
+                        Text(collectedItems.isCollected(item: gpsStaircase.id) ? "정복 완료" : "정복 대기")
                     }
                 })
                 .buttonStyle(.borderedProminent)
-                .tint(collectedItems.isCollected(item: localStaircase.id) ? .green : .yellow)
+                .tint(collectedItems.isCollected(item: gpsStaircase.id) ? .green : .yellow)
             }
         }
     }

--- a/StepSquad/StepSquad/View/TestLocalStaircaseVerification.swift
+++ b/StepSquad/StepSquad/View/TestLocalStaircaseVerification.swift
@@ -1,0 +1,34 @@
+//
+//  TestLocalStaircaseVerification.swift
+//  StepSquad
+//
+//  Created by Groo on 2/21/25.
+//
+
+import SwiftUI
+
+struct TestLocalStaircaseVerification: View {
+    @Binding var collectedItems: CollectedItems
+    var body: some View {
+        List {
+            ForEach(localStaircases) { localStaircase in
+                Button(action: {
+                    // TODO: 인증 완료 후 획득 재료에 추가하고, 게임센터 성취로 전달, 리스트에서 뷰 변경 필요
+                    if collectedItems.isCollected(item: localStaircase.id) {
+                        collectedItems.deleteItem(item: localStaircase.id)
+                    } else {
+                        collectedItems.collectItem(item: localStaircase.id, collectedDate: Date.now)
+                    }
+                }, label: {
+                    HStack {
+                        Text(localStaircase.name)
+                        Spacer()
+                        Text(collectedItems.isCollected(item: localStaircase.id) ? "정복 완료" : "정복 대기")
+                    }
+                })
+                .buttonStyle(.borderedProminent)
+                .tint(collectedItems.isCollected(item: localStaircase.id) ? .green : .yellow)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
GPSStaircase 모델을 만들었고, 뷰 구현을 위한 예시를 gpsStaircases로 설정해두었습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #191 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
- TestLocalStaircaseVerification에서 gpsStaircases를 리스트로 보여줍니다.
- collectedItems.isCollected(item: gpsStaircase.id)를 통해 계단 정복 여부를 확인할 수 있습니다. 그러기 위해선 현재 메인뷰의 collectedItems를 binding으로 활용해야 합니다.

![IMG_5854](https://github.com/user-attachments/assets/4176822a-af5a-487d-bc34-8ac5689979cf) | ![IMG_5855](https://github.com/user-attachments/assets/01e0028c-a976-4920-ba98-470e1e8b01e8) | ![IMG_5856](https://github.com/user-attachments/assets/37b18ac5-ab4f-4ab3-938c-3f5e068ccbfd)
|---|---|---|

## 🔥 Test
<!-- Test -->
